### PR TITLE
Single Sign On fixes, (Enhancement) login toggle

### DIFF
--- a/category.php
+++ b/category.php
@@ -6,26 +6,23 @@
     $categoryId = $_GET['categoryId'];
     $category = getCategoryById($categoryId, $pdo);
 
-    foreach($category as $cat){
-
-        $data = ['cat_name' => $cat->cat_name];
-    }
+    $categoryName = getCategoryName($categoryId, $pdo);
 ?>
 
 <div class="card mt-4">
-    <h5 class="card-header"><?php echo $data['cat_name']; ?></h5>
+    <h5 class="card-header"><?php echo $categoryName; ?></h5>
 </div>
 
 <?php foreach($category as $cat): ?>
 
     <div class="card mt-3">
         <div class="list-group">
-            <h6 class="mb-0"><a href="puzzle.php?puzzleId=<?php echo $cat->puzzle_id; ?>" class="list-group-item list-group-item-action bg-light text-primary"><?php echo $cat->title; ?></a></h6>
+            <h6 class="mb-0"><a href="puzzle.php?puzzleId=<?php echo $cat['puzzle_id']; ?>" class="list-group-item list-group-item-action bg-light text-primary"><?php echo $cat['title']; ?></a></h6>
             <div class="card-body">
                 <p class="card-text text-muted">
-                    <?php echo $cat->description; ?>
-                    <br>Author: <?php echo $cat->first_name . ' ' . $cat->last_name; ?>
-                    <br>Added: <?php echo $cat->created_on; ?>
+                    <?php echo $cat['description']; ?>
+                    <br>Author: <?php echo $cat['first_name'] . ' ' . $cat['last_name']; ?>
+                    <br>Added: <?php echo $cat['created_on']; ?>
                 </p>
             </div>
         </div>

--- a/helpers/authentication.php
+++ b/helpers/authentication.php
@@ -1,0 +1,69 @@
+<?php
+/*
+NOTE: Do NOT upload this file to the live site when $development_environment is set to true!
+The following boolean values exist for developing and testing this application on a stand-alone basis on localhost.
+Usage:
+- Set $development_environment to true.
+- To see what the site looks like when logged in as a regular user, set $logged_in to true and $admin and $super_admin to false.
+- To see what the site looks like when logged in as an admin, set $logged_in and $admin to true, and $super_admin to false.
+- To see what the site looks like when logged in as a super_admin, set $logged_in and $super_admin to true.
+- To see what the site looks like when logged in as an author, set $logged_in and $author to true.
+- To see what the site looks like when logged in as a sponsor, set $logged_in and $sponsor to true.
+- To see what the site looks like when not logged in, set $logged_in to false.
+*/
+// set this to true to manually change logged in/admin status
+$development_environment = false;
+// set this to true to test what the app looks like when logged in, and false to test not logged in
+$logged_in = false;
+// set this to true to test what the app looks like for admins (note: if super_admin is true, that will take priority)
+$admin = false;
+// set this to true to test what the app looks like for super_admins
+$super_admin = false;
+// set this to true to test what the app looks like for authors
+$author = false;
+// set this to true to test what the app looks like for sponsors
+$sponsor = false;
+
+// this sets the role string, do not edit
+if ($super_admin) {
+    $role = 'SUPER_ADMIN';
+} elseif ($admin) {
+    $role = 'ADMIN';
+} elseif ($sponsor) {
+    $role = 'SPONSOR';
+} else {
+    $role = 'USER';
+}
+
+/**
+ * A function to check if the user is logged in to the app according to the development environment
+ *  variables.
+ * 
+ * @return boolean if the user is logged in, false otherwise.
+ */
+function developer_is_logged_in() {
+    // localhost development logic
+    global $development_environment;
+    if ($development_environment) {
+        global $logged_in;
+        // logged_in test for development purposes
+        if ($logged_in) {
+            global $role;
+            // Session variables for localhost testing
+            $_SESSION['user_id'] = 1;
+            $_SESSION['email'] = 'test@test.test';
+            $_SESSION['first_name'] = 'First_name';
+            $_SESSION['last_name'] = 'Last_name';
+            $_SESSION['role'] = $role;
+            $_SESSION['logged_in'] = true;
+        } else {
+            // clear session variables for development environment if not logged in
+            unset($_SESSION['user_id']);
+            unset($_SESSION['email']);
+            unset($_SESSION['first_name']);
+            unset($_SESSION['last_name']);
+            unset($_SESSION['role']);
+            unset($_SESSION['logged_in']);
+        }
+    }
+}

--- a/helpers/functions.php
+++ b/helpers/functions.php
@@ -81,9 +81,9 @@
     function add_user_data(&$puzzles) {
         foreach ($puzzles as &$puzzle) {
             // for live
-            require_once '/home2/icsbinco/public_html/telugupuzzles/db_configuration.php';
+            //require_once '/home2/icsbinco/public_html/telugupuzzles/db_configuration.php';
             // for localhost
-            //require_once '../telugupuzzles/db_configuration.php';
+            require_once '../telugupuzzles/db_configuration.php';
             // connect to the telugupuzzles database
             $telugu_puzzles_pdo = pdo_connect_to_db();
 
@@ -254,9 +254,9 @@
      */
     function search_authors($query, $pdo) {
         // for live
-        require_once '/home2/icsbinco/public_html/telugupuzzles/db_configuration.php';
+        //require_once '/home2/icsbinco/public_html/telugupuzzles/db_configuration.php';
         // for localhost
-        //require_once '../telugupuzzles/db_configuration.php';
+        require_once '../telugupuzzles/db_configuration.php';
         // connect to the telugupuzzles database
         $telugu_puzzles_pdo = pdo_connect_to_db();
 

--- a/helpers/session_start.php
+++ b/helpers/session_start.php
@@ -1,8 +1,8 @@
 <?php
 if (session_status() == PHP_SESSION_NONE) {
     // adjust the session path to the main domain's location
-    ini_set('session.save_path', '/var/cpanel/php/sessions/ea-php73');
+    //ini_set('session.save_path', '/var/cpanel/php/sessions/ea-php73'); // does not work on localhost, uncomment for live site
     // set the cookie params in order to find the main domain's session
-    session_set_cookie_params(0, '/', '.telugupuzzles.com');
+    //session_set_cookie_params(0, '/', '.telugupuzzles.com'); // does not work on localhost, uncomment for live site
     session_start();
 }

--- a/helpers/sessions.php
+++ b/helpers/sessions.php
@@ -11,20 +11,8 @@
         header( "Pragma: no-cache" );
     }
 
-    function isLoggedIn(){
-        return is_logged_in();
-    }
-
-    function isAdmin(){
-        if(isLoggedIn() && $_SESSION['role'] == 'admin'){
-            return true;
-        } else {
-            return false;
-        }
-    }
-
     function regUser(){
-        if(!isLoggedIn()){
+        if(!is_logged_in()){
             redirect('index.php');
         }
     }

--- a/helpers/user_sessions.php
+++ b/helpers/user_sessions.php
@@ -1,4 +1,6 @@
 <?php
+require_once 'authentication.php';
+
 ///* Local testing 
 // user sessions database information
 DEFINE('USER_SESSIONS_DATABASE_HOST', 'localhost');
@@ -6,7 +8,7 @@ DEFINE('USER_SESSIONS_DATABASE_NAME', 'puzzleapps_db');
 DEFINE('USER_SESSIONS_DATABASE_USERNAME', 'root');
 DEFINE('USER_SESSIONS_DATABASE_PASSWORD', '');
 // this app's id
-$app_id = 6;
+$app_id = 6; // note: this may be different for your local database
 // links
 DEFINE('LOGIN_LINK', "http://localhost/telugupuzzles/login.php?app_id=" . $app_id);
 DEFINE('LOGOUT_LINK', "http://localhost/telugupuzzles/logout.php");
@@ -110,8 +112,49 @@ function logout() {
  * @return True if the user is logged in, false otherwise.
  */
 function is_logged_in() {
+    developer_is_logged_in();
+
     if (isset($_SESSION['logged_in'])) {
         if ($_SESSION['logged_in']) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * A function to check if the user is an admin.
+ * 
+ * @return True if the user has admin priviledges, false otherwise.
+ */
+function is_admin() {
+    if (isset($_SESSION['role']) && is_logged_in()) {
+        if ($_SESSION['role'] == 'ADMIN' || $_SESSION['role'] == 'SUPER_ADMIN'){
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * A function to check if the user is a super-admin.
+ * 
+ * @return True if the user has super-admin priviledges, false otherwise.
+ */
+function is_super_admin() {
+    if (!isset($_SESSION['logged_in'])) {return false;}
+    if (!isset($_SESSION['role'])) {return false;}
+    return ($_SESSION['logged_in'] and $_SESSION['role'] == 'SUPER_ADMIN');
+} 
+
+/**
+ * A function to check if the user has sponsor access.
+ * 
+ * @return True if the user has sponsor access, false otherwise.
+ */
+function is_sponsor() {
+    if (isset($_SESSION['role']) && is_logged_in()) {
+        if ($_SESSION['role'] == 'SPONSOR'){
             return true;
         }
     }
@@ -134,18 +177,4 @@ function is_author($user_id) {
         }
     }
     return $_SESSION['wordfind_author'];
-}
-
-/**
- * A function to check if the user is an admin to the app.
- * 
- * @return True if the user has admin priviledges, false otherwise.
- */
-function is_admin() {
-    if (isset($_SESSION['role']) && is_logged_in()) {
-        if ($_SESSION['role'] == 'ADMIN' || $_SESSION['role'] == 'SUPER_ADMIN'){
-            return true;
-        }
-    }
-    return false;
 }

--- a/includes/header.php
+++ b/includes/header.php
@@ -4,6 +4,7 @@
     require_once 'helpers/functions.php';
     require_once 'helpers/sessions.php';
     require_once 'indic-wp/word_processor.php';
+    //require_once '../indic-wp/word_processor.php';
 
     // enable error logging to a custom file
     ini_set("log_errors", 1); 
@@ -46,7 +47,7 @@
                 <div class="navbar-nav">
                     <a href="index.php" class="nav-item nav-link <?php echo ($pageTitle == 'Word Find') ? ' active' : '' ; ?>">Home</a>
 
-                <?php if(isLoggedIn()) : ?>
+                <?php if(is_logged_in()) : ?>
                     <a href="create_puzzle.php" class="nav-item nav-link <?php echo ($pageTitle == 'Word Find Puzzle Maker') ? ' active' : '' ; ?>">Create Puzzle</a>
                     <a href="?logout" class="nav-item nav-link">Logout</a>
                 <?php else: ?>
@@ -60,7 +61,7 @@
                 </div>
 
                 <form id="search" class="form-inline" action="search.php" method="post">
-                    <span class="text-white mr-3"><?php echo (isLoggedIn()) ? 'Welcome, ' . $_SESSION['first_name'] . ' ' . $_SESSION['last_name'] : '' ; ?></span>
+                    <span class="text-white mr-3"><?php echo (is_logged_in()) ? 'Welcome, ' . $_SESSION['first_name'] . ' ' . $_SESSION['last_name'] : '' ; ?></span>
                     <input class="form-control mr-sm-2" type="search" name="query" placeholder="category, title, author, date created" onfocus="this.placeholder = ''" onblur="this.placeholder = 'category, title, author, date created'" size="33" aria-label="Search" value="<?php echo isset($_POST['query']) ? $_POST['query'] : ''; ?>">
                     <button class="btn btn-outline-light my-2 my-sm-0" type="submit">Search</button>
                 </form>

--- a/puzzle.php
+++ b/puzzle.php
@@ -87,11 +87,11 @@
                             <label class="custom-control-label" for="toggleLabels">Labels</label>
                         </div>
 
-                        <?php if(isLoggedIn()):?>
+                        <?php if(is_logged_in()):?>
                         <div class="custom-control custom-switch custom-control-inline mt-1">
                             <input type="hidden" name="toggle_solution_lines" class="toggle-solution-options" value="0">
                             <input type="checkbox" class="custom-control-input toggle-solution-options" name="toggle_solution_lines" id="toggleSolutionLines" value="1"<?php echo (isset($_COOKIE['solution_lines']) && $_COOKIE['solution_lines'] == 1) ? ' checked ' : ''; ?>>
-                            <?php if(isAdmin() || isset($_SESSION['user_id']) && $_SESSION['user_id'] == $data['user_id']): ?> 
+                            <?php if(is_admin() || isset($_SESSION['user_id']) && $_SESSION['user_id'] == $data['user_id']): ?> 
                             <label class="custom-control-label" for="toggleSolutionLines">Solution</label>
                             <?php endif; ?>
                         </div>
@@ -100,7 +100,7 @@
 
                     <div id="controlBtns" class="col-auto mt-3 mt-md-0">
                         <button type="button" id="play" class="btn btn-outline-primary btn-sm">Play</button>
-                        <?php if(isAdmin() || isset($_SESSION['user_id']) && $_SESSION['user_id'] == $data['user_id']): ?>
+                        <?php if(is_admin() || isset($_SESSION['user_id']) && $_SESSION['user_id'] == $data['user_id']): ?>
                             <a href="edit_puzzle.php?id=<?php echo $puzzleId; ?>"><button type="button" id="edit" name = "edit_puzzle" class="btn btn-outline-primary btn-sm">Edit</button></a>
                         <button type="submit" id="delete" name="delete_puzzle" class="btn btn-outline-primary btn-sm">Delete</button>
                         <?php endif; ?>
@@ -136,7 +136,7 @@
 
 <?php
 
-    if(isLoggedIn()){
+    if(is_logged_in()){
         addSolution($data);
     }
     

--- a/search.php
+++ b/search.php
@@ -34,23 +34,23 @@
             ?>
 
 
-    <?php foreach($query as $puzzle): ?>
+    <?php if (!is_null($query)) { foreach($query as $puzzle): ?>
 
     <div class="card mt-3">
         <div class="list-group">
-            <h6 class="mb-0"><a href="puzzle.php?puzzleId=<?php echo $puzzle->puzzle_id; ?>" class="list-group-item list-group-item-action bg-light text-primary"><?php echo $puzzle->title; ?></a></h6>
+            <h6 class="mb-0"><a href="puzzle.php?puzzleId=<?php echo $puzzle['puzzle_id']; ?>" class="list-group-item list-group-item-action bg-light text-primary"><?php echo $puzzle['title']; ?></a></h6>
             <div class="card-body">
                 <p class="card-text text-muted">
-                    <?php echo $puzzle->description; ?>
-                    <br>Found in: <a href="category.php?categoryId=<?php echo $puzzle->cat_id; ?>" class="card-link"><?php echo $puzzle->cat_name; ?></a>
-                    <br>Author: <?php echo $puzzle->first_name . ' ' . $puzzle->last_name; ?>
-                    <br>Added: <?php echo $puzzle->created_on; ?>
+                    <?php echo $puzzle['description']; ?>
+                    <br>Found in: <a href="category.php?categoryId=<?php echo $puzzle['cat_id']; ?>" class="card-link"><?php echo $puzzle['cat_name']; ?></a>
+                    <br>Author: <?php echo $puzzle['first_name'] . ' ' . $puzzle['last_name']; ?>
+                    <br>Added: <?php echo $puzzle['created_on']; ?>
                 </p>
             </div>
         </div>
     </div>
 
-    <?php endforeach; ?>
+    <?php endforeach; } ?>
 
 
     <?php if(sizeof($query) != 0): ?>


### PR DESCRIPTION
Single Sign On fixes:
After single sign on, user information is kept in telugupuzzles database rather than wordfind database. Several bugs were occurring due to wordfind still trying to pull user information from its own database.
- Fixed category.php page to pull author names from telugupuzzles.
- Fixed search to search author names from telugupuzzles.
- Bug: Puzzles created before switch to single sign on will not show the author name, due to the author not existing in telugupuzzles database.

(Enhancement) login toggle:
- Added boolean variables which allow developers to toggle on and off 'logged_in', 'admin', etc.
- This will allow a user developing on localhost to see what the site looks like when logged in as a user or admin without having to download and set up the main telugu puzzles site and database.